### PR TITLE
Feature Update bash variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+ifeq (x$(PS4SDKSRC), x)
+  export PS4SDKSRC=$(shell pwd)
+endif
+
 .DEFAULT_GOAL := all
 
 %:
@@ -5,3 +9,17 @@
 	$(MAKE) -C common $@ $?
 	$(MAKE) -C extension $@ $?
 	$(MAKE) -C core $@ $?
+
+
+# PS4SDK just should use it for the installation process to copy the files
+
+install:
+	if test ! -d $(PS4SDK) ; then \
+		mkdir -p $(PS4SDK) ; \
+	fi
+	
+	cp -R ./include $(PS4SDK)/include
+	cp -R ./make $(PS4SDK)/make
+	cp -R ./lib $(PS4SDK)/lib
+	cp crt0.s $(PS4SDK)
+	cp linker.x $(PS4SDK)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Currently, running user and kernel code on firmwares ~**5.05** is supported.
 
 ## Prerequisites
 * A unix or linux system, VM or Container
-	* for OSX you will need to build clang and binutils from source 
+	* If your OS doesn't have Clang installed you will need to build clang and binutils from source 
 	* for Windows, i dont use it so no help from me
 * `clang 3.7` or later
 * `make`
@@ -55,7 +55,7 @@ For macOS
   cmake --build . --target install
   ```
   
-  After compiling and install you will have a fresh clang 7.0 with the same compiling options from Sony. However Sony is using propietary linker so we need a valid linker for macOS(freebsd has not this problem already has one).
+  After compiling and install you will have a fresh clang using latest version with the same compiling options from Sony. However Sony is using propietary linker so we need a valid linker for macOS(freebsd has not this problem already has one).
   
   Download binutils 2.25 and compile it with:
   ```
@@ -77,40 +77,40 @@ For macOS
   cat orbidev.sh
   PS4DEV=/usr/local/orbisdev;export PS4DEV
   PATH=$PS4DEV/host-osx/x86_64-pc-freebsd9/bin:$PS4DEV/toolchain/bin:$PATH
-  PS4SDK=$PS4DEV;export PS4SDK
+  ```
   
-  clang is searching for orbis-ld when you compile to fix that :
+  Clang is searching for orbis-ld when you compile to fix that :
   
   ```
   cd /usr/local/orbisdev/host-osx/x86_64-pc-freebsd9/bin
   cp ld orbis-ld
   ```
   
+  Now we can compile valid elf for PlayStation 4 from macOS :)
   
-  now we can compile valid elf for PlayStation 4 from macOS :)
-  
-
 
 ## Building
-```bash
-cd /usr/local/orbisdev
-. ./orbisdev.sh
-git clone https://github.com/psxdev/ps4sdk
-cd ps4sdk
-PS4SDK=/usr/local/orbisdev/git/ps4sdk;export PS4SDK
+The building process is quite easy, just do
+```
 make
 ```
+
 This will take some time, as it will build all libraries. In addition, if you are updating
 from a **git pull**, `make clean && make` instead of `make` may be required (and is advised),
 to ensure proper functionality.
 
+## Instalation
+
+Before continue you need to be sure that the `PS4SDK` bash variable has been defined, because is in the specific folder used during the instalation process.
+
+You can do something as:
+```
+export PS4SDK=/usr/local/orbisdev/ps4sdk
+```
+
 If all was fine install with:
 ```
-cp -frv include $PS4DEV
-cp -frv make $PS4DEV
-cp -frv lib $PS4DEV
-cp crt0.s $PS4DEV
-cp linker.x $PS4DEV
+make install
 ```
 
 ## Running code

--- a/base/Makefile
+++ b/base/Makefile
@@ -1,20 +1,8 @@
-ifndef Ps4Sdk
-ifdef ps4sdk
-Ps4Sdk := $(ps4sdk)
-endif
-ifdef PS4SDK
-Ps4Sdk := $(PS4SDK)
-endif
-ifndef Ps4Sdk
-$(error Neither PS4SDK, Ps4Sdk nor ps4sdk set)
-endif
-endif
-
 target ?= ps4_lib_no_all
-BuildPath := $(Ps4Sdk)/build
-OutPath := $(Ps4Sdk)/lib
+BuildPath := $(PS4SDKSRC)/build
+OutPath := $(PS4SDKSRC)/lib
 
-include $(Ps4Sdk)/make/ps4sdk.mk
+include $(PS4SDKSRC)/make/ps4sdk.mk
 
 define generateCObject
 $(patsubst %,$(BuildPath)/%,$(patsubst %.c,%.o,$(1))): $(1)

--- a/common/Makefile
+++ b/common/Makefile
@@ -1,20 +1,8 @@
-ifndef Ps4Sdk
-ifdef ps4sdk
-Ps4Sdk := $(ps4sdk)
-endif
-ifdef PS4SDK
-Ps4Sdk := $(PS4SDK)
-endif
-ifndef Ps4Sdk
-$(error Neither PS4SDK, Ps4Sdk nor ps4sdk set)
-endif
-endif
-
 target ?= ps4_lib_no_all
-BuildPath := $(Ps4Sdk)/build
-OutPath := $(Ps4Sdk)/lib
+BuildPath := $(PS4SDKSRC)/build
+OutPath := $(PS4SDKSRC)/lib
 
-include $(Ps4Sdk)/make/ps4sdk.mk
+include $(PS4SDKSRC)/make/ps4sdk.mk
 
 define generateCObject
 $(patsubst %,$(BuildPath)/%,$(patsubst %.c,%.c.o,$(1))): $(1)

--- a/core/Makefile
+++ b/core/Makefile
@@ -1,25 +1,12 @@
 ###################################
 
-Ps4Sdk ?= $(CURDIR)/..
-
 target := ps4_lib_no_all
-BuildPath := $(Ps4Sdk)/build
-OutPath := $(Ps4Sdk)/lib
+BuildPath := $(PS4SDKSRC)/build
+OutPath := $(PS4SDKSRC)/lib
 
 ###################################
 
-ifndef Ps4SdkFlags
-ifdef ps4sdkflags
-Ps4SdkFlags := $(ps4sdkflags)
-endif
-ifdef PS4SDKCFLAGS
-Ps4SdkFlags := $(PS4SDKCFLAGS)
-endif
-endif
-
-###################################
-
-include $(Ps4Sdk)/make/ps4sdk.mk
+include $(PS4SDKSRC)/make/ps4sdk.mk
 
 archive2 = $(Archiver) $(ArchiverFlags)
 

--- a/extension/Makefile
+++ b/extension/Makefile
@@ -1,21 +1,9 @@
-ifndef Ps4Sdk
-ifdef ps4sdk
-Ps4Sdk := $(ps4sdk)
-endif
-ifdef PS4SDK
-Ps4Sdk := $(PS4SDK)
-endif
-ifndef Ps4Sdk
-$(error Neither PS4SDK, Ps4Sdk nor ps4sdk set)
-endif
-endif
-
 target ?= ps4_lib_no_all
-BuildPath := $(Ps4Sdk)/build
-OutPath := $(Ps4Sdk)/lib
+BuildPath := $(PS4SDKSRC)/build
+OutPath := $(PS4SDKSRC)/lib
 IncludePath := -I$(wildcard */*/include) #FIXME: Need to gen correctly
 
-include $(Ps4Sdk)/make/ps4sdk.mk
+include $(PS4SDKSRC)/make/ps4sdk.mk
 
 define generateCObject
 $(patsubst %,$(BuildPath)/%,$(patsubst %.c,%.o,$(1))): $(1)

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,0 @@
-#After compiling you can use this to install all you need
-cp -frv include $PS4DEV
-cp -frv make $PS4DEV
-cp -frv lib $PS4DEV
-cp crt0.s $PS4DEV
-cp linker.x  $PS4DEV
-

--- a/make/target/ps4_bin.mk
+++ b/make/target/ps4_bin.mk
@@ -27,7 +27,7 @@ endif
 
 ###################################
 
-LinkerFlags += -Xlinker -T $(Ps4Sdk)/linker.x -Wl,--build-id=none
+LinkerFlags += -Xlinker -T $(PS4SDK)/linker.x -Wl,--build-id=none
 
 ###################################
 

--- a/make/target/x64_nostd.mk
+++ b/make/target/x64_nostd.mk
@@ -6,7 +6,7 @@ include $(MakePath)/trait/link.mk
 
 ###################################
 
-CrtFile ?= $(Ps4Sdk)/crt0.s
+CrtFile ?= $(Ps4SDK)/crt0.s
 #CrtFile ?= crt0/crt0.s
 #link = $(Linker) $? $(LinkerFlags) $(Libraries) -o $@
 

--- a/make/trait/ps4_untargeted.mk
+++ b/make/trait/ps4_untargeted.mk
@@ -1,27 +1,31 @@
 ###################################
 
-ifndef Ps4Sdk
+ifdef PS4SDKSRC
+PS4SDK = $(PS4SDKSRC)
+endif
+
+ifndef PS4SDK
 ifdef ps4sdk
-Ps4Sdk := $(ps4sdk)
+PS4SDK := $(ps4sdk)
 endif
 ifdef PS4SDK
-Ps4Sdk := $(PS4SDK)
+PS4SDK := $(PS4SDK)
 endif
-ifndef Ps4Sdk
-$(error Neither PS4SDK, Ps4Sdk nor ps4sdk set)
+ifndef PS4SDK
+$(error Neither PS4SDKSRC, PS4SDK, Ps4Sdk nor ps4sdk set)
 endif
 endif
 
 ###################################
 
-AssemblerFlags += -I$(Ps4Sdk)/include
-CompilerFlags += -D__PS4__ -I$(Ps4Sdk)/include -I $(Ps4Sdk)/include/sce
-CompilerFlagsCpp += -D__PS4__ -I$(Ps4Sdk)/include -I $(Ps4Sdk)/include/sce -I$(Ps4Sdk)/include/c++ -I$(Ps4Sdk)/include/c++/tr1
-LinkerFlags += -L$(Ps4Sdk)/lib
+AssemblerFlags += -I$(PS4SDK)/include
+CompilerFlags += -D__PS4__ -I$(PS4SDK)/include -I $(PS4SDK)/include/sce
+CompilerFlagsCpp += -D__PS4__ -I$(PS4SDK)/include -I $(PS4SDK)/include/sce -I$(PS4SDK)/include/c++ -I$(PS4SDK)/include/c++/tr1
+LinkerFlags += -L$(PS4SDK)/lib
 
 ###################################
 
-CrtFile ?= $(Ps4Sdk)/crt0.s
+CrtFile ?= $(PS4SDK)/crt0.s
 #link = $(Linker) $(Ps4Sdk)/crt0.s $? $(LinkerFlags) $(Libraries) -o $@
 
 ###################################


### PR DESCRIPTION
## Overview

This PR is just making easier the compilation fo the `ps4sdk`.
Now the bash variable `PS4SDK` is just necessary for the installation.

Additionally, the readme has been updated with new information.

Thanks